### PR TITLE
Support -c and --config with Config File

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,4 @@ To convert all Markdown files in a folder, provide the folder path:
 python til_converter.py /path/to/folder
 
 ## Example 3: Convert a Single File Using Options Specified in a Config File
-
-# Option 1: use command line arguments:
-python til_converter.py examples/sample.txt --output "./build" 
---stylesheet "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
-
-# Option 2: use a config file
 python til_converter.py examples/sample.txt -c examples/config.toml

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ python til_converter.py post.txt
 To convert all Markdown files in a folder, provide the folder path:
 python til_converter.py /path/to/folder
 
-## Example 3: Convert a Single File Using Options Specified in a Config File Instead of Command-Line Options
+## Example 3: Convert a Single File Using Options Specified in a Config File
 ```bash
 # Option 1: use command line arguments:
-python til_converter.py examples/sample.txt --output "./build" --stylesheet "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
+python til_converter.py examples/sample.txt --output "./build" 
+--stylesheet "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
 
 # Option 2: use a config file
 python til_converter.py examples/sample.txt -c examples/config.toml

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To use TIL Converter, you need to have Python and the required libraries install
 
 ```bash
 pip install markdown
+pip install tomlkit
 
 ## Usage
 To convert a Markdown file to HTML, run the following command:
@@ -16,6 +17,7 @@ python til_converter.py input.txt
 Command-Line Options
 -o, --output: Specify the output directory (default is "til").
 -s, --stylesheet: Use a custom CSS stylesheet.
+-c, --config: Use a config file to specify command-line options.
 ...
 
 ## Examples
@@ -27,5 +29,11 @@ python til_converter.py post.txt
 To convert all Markdown files in a folder, provide the folder path:
 python til_converter.py /path/to/folder
 
+## Example 3: Convert a Single File Using Options Specified in a Config File Instead of Command-Line Options
+```bash
+# Option 1: use command line arguments:
+python til_converter.py examples/sample.txt --output "./build" --stylesheet "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
 
-
+# Option 2: use a config file
+python til_converter.py examples/sample.txt -c examples/config.toml
+```

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ To convert all Markdown files in a folder, provide the folder path:
 python til_converter.py /path/to/folder
 
 ## Example 3: Convert a Single File Using Options Specified in a Config File
-```bash
+
 # Option 1: use command line arguments:
 python til_converter.py examples/sample.txt --output "./build" 
 --stylesheet "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
 
 # Option 2: use a config file
 python til_converter.py examples/sample.txt -c examples/config.toml
-```

--- a/TIL tool project/examples/config.toml
+++ b/TIL tool project/examples/config.toml
@@ -1,0 +1,2 @@
+output = "./build"
+stylesheet = "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"

--- a/TIL tool project/til_converter.py
+++ b/TIL tool project/til_converter.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+import sys
 import markdown2
 from tomlkit.toml_file import TOMLFile
 
@@ -57,18 +58,51 @@ def get_config_file_data(config_file):
         return None
 
 def main():
+    output_path = None
+    stylesheet_url = None
+
     # Parse command-line arguments
     parser = argparse.ArgumentParser(description='TIL Tool - Convert Markdown to HTML')
     parser.add_argument('input', help='Input .txt file')
     parser.add_argument('-o', '--output', default='til', help='Output directory for HTML files')
     parser.add_argument('-s', '--stylesheet', help='Custom stylesheet URL')
+    parser.add_argument('-c', '--config', help='Use config file instead of command-line args')
     args = parser.parse_args()
 
+    # Check if user has opted to use a config file
+    if args.config:
+        # If config file does not exist, exit with error message
+        if not os.path.isfile(args.config):
+            print(f"Error: Config file {args.config} does not exist\n")
+            sys.exit()
+
+        # Extract data from config file into a dictionary-like object
+        config_args = get_config_file_data(args.config)
+
+        # If data extraction from config file failed, exit with error message
+        if not config_args:
+            print(f"Error: Unable to parse config file {args.config} as TOML\n")
+            sys.exit()
+        
+        # Get output path from config file
+        if "output" in config_args:
+            output_path = config_args["output"]
+
+        # Get stylesheet url from config file
+        if "stylesheet" in config_args:
+            stylesheet_url = config_args["stylesheet"]
+    else:
+        # Get output path from command-line args
+        output_path = args.output
+
+        # Get stylesheet url from command-line args
+        stylesheet_url = args.stylesheet 
+
     # Create the output folder if it doesn't exist
-    os.makedirs(args.output, exist_ok=True)
+    os.makedirs(output_path, exist_ok=True)
 
     # Process the input file
-    process_file(args.input, args.output, args.stylesheet)
+    process_file(args.input, output_path, stylesheet_url)
 
 if __name__ == '__main__':
     main()

--- a/TIL tool project/til_converter.py
+++ b/TIL tool project/til_converter.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 import markdown2
+from tomlkit.toml_file import TOMLFile
 
 def convert_to_html(markdown_text):
     # Convert Markdown to HTML
@@ -37,6 +38,23 @@ def process_file(input_file, output_folder, stylesheet_url=None):
 
         # Close the HTML tags
         file.write('\n</body>\n</html>')
+
+def get_config_file_data(config_file):
+    """
+    Reads a config file and returns the data in a TOMLDocument object.
+    A TOMLDocument object can be used the same as a dictionary object.
+ 
+    Args:
+        config_file (String): the path of the config file (.toml file)
+ 
+    Returns:
+        TOMLDocument: the config file contents if read was successful
+        None: if read was unsuccessful (invalid config path, invalid config file contents)
+    """
+    try:
+        return TOMLFile(config_file).read()
+    except:
+        return None
 
 def main():
     # Parse command-line arguments


### PR DESCRIPTION
Added support for reading options from a config file. Closes #3 

Details of code additions:
- added function get_config_file_data for parsing the data from a config file (used open source TOML implementation [tomlkit](https://tomlkit.readthedocs.io/en/latest/))
- modified main() to accept new -c --config flag, exit with error messages if config file is nonexistent or can't be parsed; if config file is provided ignore all other flags and only read options from config file
- Updated README to include this new feature and additional installation requirement (pip install tomlkit)
- Added config.toml in examples folder to use for testing

How to quickly test the new feature:
- pip install tomlkit
- run `python til_converter.py examples/sample.txt -c examples/config.toml`
- this should give you the same output as `python til_converter.py examples/sample.txt --output "./build" --stylesheet "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"`